### PR TITLE
Build fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "katex": "~0.4.3"
+  }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,30 +1,28 @@
 var gulp = require('gulp'),
   es6ify = require('es6ify'),
-  $ = require('gulp-load-plugins')();
+  babel = require("gulp-babel"),
+  vulcanize = require("gulp-vulcanize"),
+  rename = require("gulp-rename"),
+  debug = require('gulp-debug'),
+  connect = require("gulp-connect");
 
 gulp.task('js', function () {
-  gulp.src([
+  return gulp.src([
     'src/jupyter-display-area.js',
-  ])
-    .pipe($.plumber())
-    .pipe($.browserify({
-      add: [ es6ify.runtime ],
-      transform: ['es6ify']
-    }))
-    .pipe($.uglify())
+    ]).pipe(babel())
     .pipe(gulp.dest('dist'));
 });
 
 gulp.task('html', function () {
   gulp.src('src/jupyter-display-area.html')
-    .pipe($.rename('jupyter-display-area.local.html'))
+    .pipe(rename('jupyter-display-area.local.html'))
     .pipe(gulp.dest('dist'));
 });
 
 gulp.task('vulcanize', function () {
   gulp.src('dist/jupyter-display-area.local.html')
-    .pipe($.vulcanize({dest: 'dist', inline: true}))
-    .pipe($.rename('jupyter-display-area.html'))
+    .pipe(vulcanize({dest: 'dist', inline: true}))
+    .pipe(rename('jupyter-display-area.html'))
     .pipe(gulp.dest('dist'));
 });
 
@@ -44,12 +42,12 @@ gulp.task('default', ['build', 'connect'], function () {
 
   gulp.watch(['index.html', 'dist/**.*'], function (event) {
     return gulp.src(event.path)
-      .pipe($.connect.reload());
+      .pipe(connect.reload());
   });
 });
 
 gulp.task('connect', function () {
-  $.connect.server({
+  connect.server({
     root: [__dirname],
     port: 1983,
     livereload: {port: 2983}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp'),
-  es6ify = require('es6ify'),
+  uglify = require('gulp-uglify'),
   babel = require("gulp-babel"),
   vulcanize = require("gulp-vulcanize"),
   rename = require("gulp-rename"),
@@ -10,6 +10,7 @@ gulp.task('js', function () {
   return gulp.src([
     'src/jupyter-display-area.js',
     ]).pipe(babel())
+    .pipe(uglify())
     .pipe(gulp.dest('dist'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,9 +40,9 @@ gulp.task('default', ['build', 'connect'], function () {
   gulp.watch(['src/*.*js'], ['js']);
   gulp.watch(['src/*.html'], ['html']);
   gulp.watch(['bower_components'], ['copy']);
-  gulp.watch(['dist/jupyter-display-area.local.html', 'dist/jupyter-display-area.js', 'dist/jupyter-display-area.css'], ['vulcanize']);
+  gulp.watch(['dist/jupyter-display-area.local.html', 'dist/jupyter-display-area.js'], ['vulcanize']);
 
-  gulp.watch(['index.html', 'dist/**.*', 'demos/**.*'], function (event) {
+  gulp.watch(['index.html', 'dist/**.*'], function (event) {
     return gulp.src(event.path)
       .pipe($.connect.reload());
   });

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       document.write('<script src="https:\/\/cdnjs.cloudflare.com/ajax/libs/polymer/0.3.4/platform.js"><\/script>')
     }
   </script>
-  <link rel="import" href="dist/jupyter-display-area.html">
+  <link rel="import" href="dist/jupyter-display-area.local.html">
   <style>
     body {
       margin: 0;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   "dependencies": {
     "es6ify": "^1.6.0",
     "gulp": "^3.9.0",
+    "gulp-babel": "^5.1.0",
     "gulp-browserify": "^0.5.1",
     "gulp-connect": "^2.2.0",
+    "gulp-debug": "^2.0.1",
     "gulp-load-plugins": "^0.10.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",

--- a/src/jupyter-display-area.js
+++ b/src/jupyter-display-area.js
@@ -7,7 +7,7 @@ class JupyterDisplayArea extends HTMLElement {
 
     this.shadow = this.createShadowRoot();
     this.shadow.appendChild(template);
-    this.outputs = this.root.getElementById("outputs");
+    this.outputs = this.shadow.getElementById("outputs");
   }
 
   /**


### PR DESCRIPTION
This fixes up the gulp process in creating the transpiled and uglified web component. Because of an issue with vulcanize + gulp, this doesn't bundle everything into one HTML file/component. It still gets used with an import:

```
<link rel="import" href="dist/jupyter-display-area.local.html">
```

But it could just be an import from `src`:

```
<link rel="import" href="src/jupyter-display-area.html">
```
