### PR TITLE
Pull data directly.

### DIFF
--- a/src/jupyter-display-area.js
+++ b/src/jupyter-display-area.js
@@ -210,7 +210,7 @@ class JupyterDisplayArea extends HTMLElement {
     _append_mime_bundle(json, metadata) {
         let element;
         for (let renderer of this.renderers) {
-            let data = json[renderer.mimetype];
+            let data = json.data[renderer.mimetype];
             if (data) {
                 element = renderer.render(data, metadata);
             }


### PR DESCRIPTION
This was (attempting) to get the mimetype directly out of the message object, which is coming in direct:

```
  {
    "blobs": [],
    "content": {
      "data": {
        "text/plain": "2"
      },
      "execution_count": 22,
      "metadata": {}
    },
    "header": {
      "date": "2015-07-09T14:24:49.315860",
      "msg_id": "0d889ee1-6a06-45dd-aade-e25aa93ec2ca",
      "msg_type": "execute_result",
      "session": "557c55be-4bf2-454b-bbab-1b66d1d9efc8",
      "username": "jovyan",
      "version": "5.0"
    },
    ],
    "metadata": {},
    "parentHeader": {
      "date": "2015-07-09T14:24:49.313681",
      "msg_id": "7b39ee80-a64e-4e37-8d9c-acdfc9acb25f",
      "msg_type": "execute_request",
      "session": "e0bd315b-abe1-4bad-ab5c-38eb4455c693",
      "username": "jovyan",
      "version": "5.0"
    }
  }
```

Were these supposed to be expecting the `content` field rather than the full message?